### PR TITLE
Fix python2 rename (#6703)

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6836,9 +6836,9 @@ class NativeFileTests(BasePlatformTests):
             '--native-file', config, '--native-file', config2,
             '-Dcase=find_program'])
 
-    def _simple_test(self, case, binary):
+    def _simple_test(self, case, binary, entry=None):
         wrapper = self.helper_create_binary_wrapper(binary, version='12345')
-        config = self.helper_create_native_file({'binaries': {binary: wrapper}})
+        config = self.helper_create_native_file({'binaries': {entry or binary: wrapper}})
         self.init(self.testcase, extra_args=['--native-file', config, '-Dcase={}'.format(case)])
 
     def test_find_program(self):
@@ -6861,16 +6861,21 @@ class NativeFileTests(BasePlatformTests):
             # python module breaks. This is fine on other OSes because they
             # don't need the extra indirection.
             raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
-        if os.path.exists('/etc/debian_version'):
-            rc = subprocess.call(['pkg-config', '--cflags', 'python2'],
-                                 stdout=subprocess.DEVNULL,
-                                 stderr=subprocess.DEVNULL)
-            if rc != 0:
-                # Python 2 will be removed in Debian Bullseye, thus we must
-                # remove the build dependency on python2-dev. Keep the tests
-                # but only run them if dev packages are available.
+        elif is_osx():
+            binary = 'python'
+        else:
+            binary = 'python2'
+
+            # We not have python2, check for it
+            for v in ['2', '2.7', '-2.7']:
+                rc = subprocess.call(['pkg-config', '--cflags', 'python{}'.format(v)],
+                                     stdout=subprocess.DEVNULL,
+                                     stderr=subprocess.DEVNULL)
+                if rc == 0:
+                    break
+            else:
                 raise unittest.SkipTest('Not running Python 2 tests because dev packages not installed.')
-        self._simple_test('python', 'python')
+        self._simple_test('python', binary, entry='python')
 
     @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')
     @skip_if_env_set('CC')


### PR DESCRIPTION
* unittests: fix finding python2 if the binary is named python2

Because of the way the python module works the simplicity of the test
function is no longer valid, we need to have and additional name
parameter to make the python module work, as it doesn't look for an
entry called "python2" or "python3", only "python"

* unittests: Don't make our python 2.x check debian specific

* unittests: On macOS the python2 binary is still called python