### PR TITLE
pkgconfig: Fix deprecation message (fixes #6720)

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -526,8 +526,7 @@ class PkgConfigModule(ExtensionModule):
             for lib in deps.pub_libs:
                 if not isinstance(lib, str) and not hasattr(lib, 'generated_pc'):
                     lib.generated_pc = filebase
-                    location = types.SimpleNamespace(subdir=state.subdir,
-                                                     lineno=state.current_lineno)
+                    location = state.current_node
                     lib.generated_pc_warn = [name, location]
         return ModuleReturnValue(res, [res])
 


### PR DESCRIPTION
Deprecation warning was unable to display because of patch
c8f8d58273a40d94c820dccab54a7ae2d948cb8a

fixes #6720