### PR TITLE
Improve regular expression for MSVC compiler target arch detection

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1063,7 +1063,7 @@ class Environment:
                     m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
                 cl_signature = lookat.split('\n')[0]
-                match = re.search('.*(x86|x64|ARM|ARM64)$', cl_signature)
+                match = re.search('.*(x86|x64|ARM|ARM64)( |$)', cl_signature)
                 if match:
                     target = match.group(1)
                 else:


### PR DESCRIPTION
Did not work for some MSVC output language combinations.
Now should work for every locale / output language.

Fixes issue #6757