### PR TITLE
syntax-highlighting/vim: Add `in` as an operator

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -33,7 +33,7 @@ set cpo&vim
 " http://mesonbuild.com/Syntax.html
 syn keyword mesonConditional	elif else if endif
 syn keyword mesonRepeat	foreach endforeach
-syn keyword mesonOperator	and not or
+syn keyword mesonOperator	and not or in
 
 syn match   mesonComment	"#.*$" contains=mesonTodo,@Spell
 syn keyword mesonTodo		FIXME NOTE NOTES TODO XXX contained


### PR DESCRIPTION
This was missed. Ages ago.